### PR TITLE
[Change] Use files + peco as file chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Currently `project_guide#open({project directories pattern})` does:
 
 1. Choose a project (UI is [peco](https://github.com/peco/peco))
 2. `:tcd {project directory}`
-3. Choose file(s) (UI is [gof](https://github.com/mattn/gof))
+3. Choose file(s) (UI is peco (+ [files](https://github.com/mattn/files)) or [gof](https://github.com/mattn/gof))
 4. `:split {file(s)}`
 
 ## Examples
@@ -141,6 +141,7 @@ And more, if you also want to complete Ex command arguments, you can use
 | `gof_args`               | List<String>                            | Addtional arguments to gof (default: `[]`)                                                                                                            |
 | `file_dialog_msg`        | String                                  | `{what}` for `popup_dialog({what}, {options})`. Used for choosing file(s). if empty({what}) is true, does not show popup (default: `'Choose a file'`) |
 | `file_dialog_options`    | Same as `{options}` of `popup_dialog()` | `{options}` for `popup_dialog({what}, {options})` (default: `#{time: 2000}`)                                                                          |
+| `file_ui`                | String                                  | Use files + peco when value is `files+peco`. otherwise gof (default: `files+peco`)                                                                                |
 | `project_dialog_msg`     | String                                  | same as `file_dialog_msg` but for choosing a project (default: `'Choose a project'`)                                                                  |
 | `project_dialog_options` | Same as `{options}` of `popup_dialog()` | same as `file_dialog_options` but for choosing a project (default: `#{time: 2000}`)                                                                   |
 | `open_func`              | Function                                | The function to open the list of file(s) given by arguments (default: `function('project_guide#default_open_func')`)                                  |


### PR DESCRIPTION
## What this PR does

* Add `file_ui` option to specify 'files+peco' or 'gof'
* Change default value of `file_ui` to `'files+peco'`

## Why

Currently using peco for project chooser, and using gof for file chooser.
However, the UIs are totally different; for example, the positions of the prompts are different (peco: top, gof: bottom).
User must moves eyes to see input string, and showing different UI so quickly gets user tired.