### PR TITLE
Load session file (Session.vim) if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ Currently `project_guide#open({project directories pattern})` does:
 
 1. Choose a project (UI is [peco](https://github.com/peco/peco))
 2. `:tcd {project directory}`
-3. Choose file(s) (UI is peco (+ [files](https://github.com/mattn/files)) or [gof](https://github.com/mattn/gof))
-4. `:split {file(s)}`
+3. If a session file (default: `Session.vim`) is found and `load_session` is enabled
+  a. Load the session file
+4. If a session file is NOT found
+  a. Choose file(s) (UI is peco (+ [files](https://github.com/mattn/files)) or [gof](https://github.com/mattn/gof))
+  b. `:split {file(s)}`
 
 ## Examples
 
@@ -141,10 +144,12 @@ And more, if you also want to complete Ex command arguments, you can use
 | `gof_args`               | List<String>                            | Addtional arguments to gof (default: `[]`)                                                                                                            |
 | `file_dialog_msg`        | String                                  | `{what}` for `popup_dialog({what}, {options})`. Used for choosing file(s). if empty({what}) is true, does not show popup (default: `'Choose a file'`) |
 | `file_dialog_options`    | Same as `{options}` of `popup_dialog()` | `{options}` for `popup_dialog({what}, {options})` (default: `#{time: 2000}`)                                                                          |
-| `file_ui`                | String                                  | Use files + peco when value is `files+peco`. otherwise gof (default: `files+peco`)                                                                                |
+| `file_ui`                | String                                  | Use files + peco when value is `files+peco`. otherwise gof (default: `files+peco`)                                                                    |
 | `project_dialog_msg`     | String                                  | same as `file_dialog_msg` but for choosing a project (default: `'Choose a project'`)                                                                  |
 | `project_dialog_options` | Same as `{options}` of `popup_dialog()` | same as `file_dialog_options` but for choosing a project (default: `#{time: 2000}`)                                                                   |
 | `open_func`              | Function                                | The function to open the list of file(s) given by arguments (default: `function('project_guide#default_open_func')`)                                  |
+| `load_session`           | Boolean                                 | Load session file or not (default: `v:true`)                                                                                                          |
+| `session_file`           | String                                  | Session file name (default: `'Session.vim'`)                                                                                                          |
 
 ### `project_guide#default_open_func(path_list, opencmd = 'split')`
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,32 @@ autocmd VimEnter * call project_guide#define_command('Gopath', function('s:gopat
 " autocmd VimEnter * call project_guide#define_command('Gopath', function('s:gopath_dirs_pattern'), #{peco_args: ['--select-1'], gof_args: ['-f']})
 ```
 
+And project-guide.vim looks up a session file under project directory if `load_session == v:true` (default: `v:true`).<br>
+You can emit the session file to restore window layout, and so on (see `:help session-file`).
+
+**Recommend:**
+By default Vim 'sessionoptions' value, it *replaces* current all open tabpages after loading a session file.
+If you want to *append* a tabpage of selected project, try `set sessionoptions-=tabpages` in your vimrc.
+
+If you want to auto-update `Session.vim` file in current project every 30 seconds:
+
+```vim
+autocmd User project-guide-post-tcd let t:vimrc_update_session_constantly = getcwd() . '/Session.vim'
+autocmd User project-guide-post-file-open execute 'mksession!' t:vimrc_update_session_constantly
+" Execute :mksession! in all tabpages which have t:vimrc_update_session_constantly
+function! s:update_session(timer) abort
+  let winid = win_getid()
+  tabdo if t:->has_key('vimrc_update_session_constantly') | execute 'mksession!' t:vimrc_update_session_constantly | endif
+  call win_gotoid(winid)
+endfunction
+" Call above function every 30 seconds
+function! s:register_update_session() abort
+  let sec = 1000
+  call timer_start(30 * sec, function('s:update_session'), #{repeat: -1})
+endfunction
+call s:register_update_session()
+```
+
 Choose a project and files to open quickly.
 
 ![](https://i.imgur.com/v1LPefs.gif)

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Currently `project_guide#open({project directories pattern})` does:
 1. Choose a project (UI is [peco](https://github.com/peco/peco))
 2. `:tcd {project directory}`
 3. If a session file (default: `Session.vim`) is found and `load_session` is enabled
-  a. Load the session file
+    1. Load the session file
 4. If a session file is NOT found
-  a. Choose file(s) (UI is peco (+ [files](https://github.com/mattn/files)) or [gof](https://github.com/mattn/gof))
-  b. `:split {file(s)}`
+    1. Choose file(s) (UI is peco (+ [files](https://github.com/mattn/files)) or [gof](https://github.com/mattn/gof))
+    2. `:split {file(s)}`
 
 ## Examples
 
@@ -31,10 +31,6 @@ autocmd VimEnter * call project_guide#define_command('Gopath', function('s:gopat
 And project-guide.vim looks up a session file under project directory if `load_session == v:true` (default: `v:true`).<br>
 You can emit the session file to restore window layout, and so on (see `:help session-file`).
 
-**Recommend:**
-By default Vim 'sessionoptions' value, it *replaces* current all open tabpages after loading a session file.
-If you want to *append* a tabpage of selected project, try `set sessionoptions-=tabpages` in your vimrc.
-
 If you want to auto-update `Session.vim` file in current project every 30 seconds:
 
 ```vim
@@ -53,6 +49,12 @@ function! s:register_update_session() abort
 endfunction
 call s:register_update_session()
 ```
+
+**Recommend:**
+By default Vim 'sessionoptions' value, it *replaces* current all open tabpages after loading a session file.<br>
+If you want to *append* a tabpage of selected project, try `set sessionoptions-=tabpages` in your vimrc.
+
+## Screenshots
 
 Choose a project and files to open quickly.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Currently `project_guide#open({project directories pattern})` does:
 
 1. Choose a project (UI is [peco](https://github.com/peco/peco))
 2. `:tcd {project directory}`
-3. Choose file(s) (UI is [gof](https://github.com/mattn/gof))
+3. Choose file(s) (UI is peco (+ [files](https://github.com/mattn/files)) or [gof](https://github.com/mattn/gof))
 4. `:split {file(s)}`
 
 ## Examples
@@ -141,6 +141,7 @@ And more, if you also want to complete Ex command arguments, you can use
 | `gof_args`               | List<String>                            | Addtional arguments to gof (default: `[]`)                                                                                                            |
 | `file_dialog_msg`        | String                                  | `{what}` for `popup_dialog({what}, {options})`. Used for choosing file(s). if empty({what}) is true, does not show popup (default: `'Choose a file'`) |
 | `file_dialog_options`    | Same as `{options}` of `popup_dialog()` | `{options}` for `popup_dialog({what}, {options})` (default: `#{time: 2000}`)                                                                          |
+| `file_ui`                | String                                  | Use files + peco when value is `files+peco`. otherwise gof (default: `files+peco`)                                                                                |
 | `project_dialog_msg`     | String                                  | same as `file_dialog_msg` but for choosing a project (default: `'Choose a project'`)                                                                  |
 | `project_dialog_options` | Same as `{options}` of `popup_dialog()` | same as `file_dialog_options` but for choosing a project (default: `#{time: 2000}`)                                                                   |
 | `open_func`              | Function                                | The function to open the list of file(s) given by arguments (default: `function('project_guide#default_open_func')`)                                  |

--- a/autoload/project_guide.vim
+++ b/autoload/project_guide.vim
@@ -13,10 +13,19 @@ function! project_guide#open(dirs_pattern, options = {}) abort
   call s:select_project(a:dirs_pattern, a:options)
 endfunction
 
+function! s:setup_nop_autocmds() abort
+  augroup project-guide
+    autocmd!
+    autocmd User project-guide-post-tcd silent
+    autocmd User project-guide-post-file-open silent
+  augroup END
+endfunction
+
 function! s:select_project(dirs_pattern, options) abort
   if !s:current_tabpage_is_empty()
     tabedit
   endif
+  call s:setup_nop_autocmds()
   " Select a project (peco)
   let in_name = tempname()
   let project_dirs = s:get_project_dirs(a:dirs_pattern)
@@ -160,6 +169,7 @@ function! s:tcd_and_select_file(peco_ctx, job, code) abort
   call delete(a:peco_ctx.in_name)
   " Change current directory to the project
   execute 'tcd' path
+  doautocmd User project-guide-post-tcd
   if a:peco_ctx.load_session && filereadable(a:peco_ctx.session_file)
     execute 'source' a:peco_ctx.session_file
     return
@@ -224,4 +234,5 @@ function! s:finalize_file_ui_cmd(file_ui, file_ctx, job, code) abort
       call win_execute(gof_winid, 'close')
     endif
   endif
+  doautocmd User project-guide-post-file-open
 endfunction

--- a/autoload/project_guide.vim
+++ b/autoload/project_guide.vim
@@ -53,6 +53,8 @@ function! s:select_project(dirs_pattern, options) abort
     \ file_dialog_options: a:options->get('file_dialog_options', #{time: 2000}),
     \ file_ui: file_ui,
     \ file_ui_cmd: file_ui_cmd,
+    \ load_session: a:options->get('load_session', v:true),
+    \ session_file: a:options->get('session_file', 'Session.vim'),
     \}
   let term_bufnr = term_start(['peco'] + peco_args, #{
     \ curwin: v:true,
@@ -158,6 +160,10 @@ function! s:tcd_and_select_file(peco_ctx, job, code) abort
   call delete(a:peco_ctx.in_name)
   " Change current directory to the project
   execute 'tcd' path
+  if a:peco_ctx.load_session && filereadable(a:peco_ctx.session_file)
+    execute 'source' a:peco_ctx.session_file
+    return
+  endif
   " Select a file to open
   let popup = empty(a:peco_ctx.file_dialog_msg) ?
     \ -1 : popup_dialog(a:peco_ctx.file_dialog_msg, a:peco_ctx.file_dialog_options)


### PR DESCRIPTION
Based on #1 

Load a session file (default: `Session.vim`) under a project directory if it exists, and won't show file chooser (`gof` or `files+peco`).
Otherwise same as the previous behavior.

And add an example code to auto-update Session.vim file constantly (every 30 seconds).

GitHub diff contains also other branches.
Diff: https://github.com/tyru/project-guide.vim/compare/f101bbb709bc2cffe630643b4c71f8e6c7455da5...ab5baf17808eb529df5f54b9250e591171f6f1c3?expand=1